### PR TITLE
Fix: Profile Page Crash

### DIFF
--- a/src/components/sub-menus/profile-options/script.ts
+++ b/src/components/sub-menus/profile-options/script.ts
@@ -115,9 +115,11 @@ export default class ProfileOptions extends Vue {
 	}
 
 	public onDeletePage(page: IPageAggregate) {
+		const profiles = this.store.profiles.getProfileNamesByPage(page);
+
 		this.$dialog.warning({
 			title: this.$t('dialogs.deletePage.title').toString(),
-			message: this.$t('dialogs.deletePage.message', { name: page.name }).toString(),
+			message: this.$t('dialogs.deletePage.message', { name: page.name, profiles: profiles.join(', ') }).toString(),
 			showButtons: true
 		}).then(() => this.server.deletePage(page));
 	}

--- a/src/i18n/en_US.json
+++ b/src/i18n/en_US.json
@@ -10,7 +10,7 @@
 		},
 		"deletePage": {
 			"title": "Delete Page",
-			"message": "Are you sure you want to delete the page \"{name}\"? The settings will be lost."
+			"message": "Are you sure you want to delete the page \"{name}\"? This page is included in the following profiles: {profiles}. The settings will be lost. "
 		},
 		"deleteGroup": {
 			"title": "Delete Group",

--- a/src/store/aggregates/profiles.ts
+++ b/src/store/aggregates/profiles.ts
@@ -39,4 +39,16 @@ export class ProfilesAggregate {
 	public profile$(id: string) {
 		return this.profiles$.pipe(map((profiles) => profiles.find((profile) => profile.id === id)));
 	}
+
+	public getProfileNamesByPage(page: IPageAggregate) {
+		const profiles = this.store.value.profiles.all;
+
+		return Object.keys(profiles)
+			.filter((key) => {
+				const profile = profiles[key];
+
+				return profile.pages.includes(page.id);
+			})
+			.map((key) => profiles[key].name);
+	}
 }


### PR DESCRIPTION
API changes can only fix #27 however, this changes updates the dialog to include what profiles a page is included in. This makes it more clear to the user how far reaching the change would be.