### PR TITLE
Fix: Missing Switch Icon

### DIFF
--- a/assets/styles/fonts.scss
+++ b/assets/styles/fonts.scss
@@ -224,7 +224,7 @@ i {
     content: $icon-playlist; 
   }
 }
-.icon-power-on {
+.icon-power-on, .icon-switch {
   &:before {
     content: $icon-power-on; 
   }


### PR DESCRIPTION
### Changes
- Added duplicate selector on the power icon so we can use it for switches